### PR TITLE
fix: goのdockerイメージをマイナーバージョンまでで固定

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.21.5-bookworm AS builder
+FROM golang:1.21-bookworm AS builder
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 go build
 
-FROM golang:1.21.5-alpine AS runner
+FROM golang:1.21-alpine3.19 AS runner
 
 WORKDIR /app
 
@@ -22,7 +22,7 @@ EXPOSE 8000
 
 CMD ["/app/app"]
 
-FROM golang:1.21.5 AS develop
+FROM golang:1.21-bookworm AS develop
 
 WORKDIR /app
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,3 @@
 module app
 
-go 1.21.5
+go 1.21


### PR DESCRIPTION
closed: #14 