### PR TITLE
feat: goのCIを作成

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,32 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: './backend/go.mod'
+          cache-dependency-path: './backend/go.sum'
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -30,3 +30,9 @@ jobs:
 
       - name: Test
         run: go test -v ./...
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          working-directory: ./backend

--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -1,0 +1,18 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  golangci-lint:
+    name: runner / golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@v2
+        with:
+          go_version: "1.21"
+          golangci_lint_flags: "--config=.golangci.yaml"
+          workdir: backend

--- a/backend/.golangci.yaml
+++ b/backend/.golangci.yaml
@@ -1,0 +1,6 @@
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - goimports
+    - gofmt


### PR DESCRIPTION
### 概要
- CIとしてビルド、テスト、lintを導入
- lintは`golangci-lint-action`を使用
- デフォルトのもの (https://golangci-lint.run/usage/linters/#enabled-by-default) + goimports、gofmtを有効化
- reviewdogも導入、linterの対象は自動でPRにレビューをくれる

related: #18 